### PR TITLE
Fix Project3D function

### DIFF
--- a/utils/geometry_utils.py
+++ b/utils/geometry_utils.py
@@ -79,10 +79,9 @@ class Project3D(jit.ScriptModule):
 
         cam_points_b3N = P_b44[:, :3] @ points_b4N
 
-        depth_b1N = torch.maximum(cam_points_b3N[:, 2:], self.eps)
-        pix_coords_b2N = cam_points_b3N[:, :2] / depth_b1N
+        pix_coords_b2N = cam_points_b3N[:, :2] / torch.maximum(cam_points_b3N[:, 2:], self.eps)
 
-        return torch.cat([pix_coords_b2N, depth_b1N], dim=1)
+        return torch.cat([pix_coords_b2N, cam_points_b3N[:, 2:]], dim=1)
 
 
 class NormalGenerator(jit.ScriptModule):


### PR DESCRIPTION
Hi authors,

I fix the `Project3D` function of `geometry_utils.py` and the reason we can see [issue#22](https://github.com/nianticlabs/simplerecon/issues/22#issue-1469499306). Original depth value are all greater or equal to `eps` because of `torch.maximum`, and this will make the mask in meta data all be `True`. Therefore, I fix the error and let this function return correct depth value.